### PR TITLE
Use MORWEB as dashboard title

### DIFF
--- a/dashboard-2.html
+++ b/dashboard-2.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MorwebCMS Dashboard</title>
+    <title>MORWEB</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <style>

--- a/dashboard-5.html
+++ b/dashboard-5.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MorwebCMS Dashboard</title>
+  <title>MORWEB</title>
   <!-- Fonts: system stack first for performance; optional Montserrat headings -->
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet"></noscript>

--- a/dashboard-final.html
+++ b/dashboard-final.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MorwebCMS Dashboard</title>
+  <title>MORWEB</title>
   <!-- Fonts: system stack first for performance; optional Montserrat headings -->
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet"></noscript>


### PR DESCRIPTION
## Summary
- Replace "MorwebCMS Dashboard" with "MORWEB" in all HTML dashboard versions so that the page title is consistent.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68a49b85099483339750cdfe3e7463db