### PR TITLE
style: arrange content section in three columns

### DIFF
--- a/dashboard-5.html
+++ b/dashboard-5.html
@@ -102,7 +102,8 @@
     .grid { display: grid; gap: 1.25rem; }
     .grid.stats { grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); }
     .grid.two { grid-template-columns: 2fr 1fr; }
-    @media (max-width: 960px) { .layout { grid-template-columns: 72px 1fr; } .grid.two { grid-template-columns: 1fr; } .nav button span { display: none; } }
+    .grid.three { grid-template-columns: repeat(3,1fr); }
+    @media (max-width: 960px) { .layout { grid-template-columns: 72px 1fr; } .grid.two { grid-template-columns: 1fr; } .grid.three { grid-template-columns: 1fr; } .nav button span { display: none; } }
 
     .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 1rem; box-shadow: var(--shadow-1); }
     .card .card-head { display: flex; align-items: center; justify-content: space-between; gap: .5rem; padding-bottom: .75rem; border-bottom: 1px solid var(--border); }
@@ -283,7 +284,7 @@
       </section>
 
       <!-- Content / Leaders / Events / etc. (condensed example) -->
-      <section class="grid" style="margin-top:1rem">
+      <section class="grid three" style="margin-top:1rem">
         <article class="card" aria-labelledby="content-health"><div class="card-head"><h3 id="content-health">Content Health Monitor</h3></div>
           <ul class="list">
             <li>

--- a/dashboard-final.html
+++ b/dashboard-final.html
@@ -102,7 +102,8 @@
     .grid { display: grid; gap: 1.25rem; }
     .grid.stats { grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); }
     .grid.two { grid-template-columns: 2fr 1fr; }
-    @media (max-width: 960px) { .layout { grid-template-columns: 72px 1fr; } .grid.two { grid-template-columns: 1fr; } .nav button span { display: none; } }
+    .grid.three { grid-template-columns: repeat(3,1fr); }
+    @media (max-width: 960px) { .layout { grid-template-columns: 72px 1fr; } .grid.two { grid-template-columns: 1fr; } .grid.three { grid-template-columns: 1fr; } .nav button span { display: none; } }
 
     .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 1rem; box-shadow: var(--shadow-1); }
     .card .card-head { display: flex; align-items: center; justify-content: space-between; gap: .5rem; padding-bottom: .75rem; border-bottom: 1px solid var(--border); }
@@ -296,7 +297,7 @@
       </section>
 
       <!-- Content / Leaders / Events / etc. (condensed example) -->
-      <section class="grid" style="margin-top:1rem">
+      <section class="grid three" style="margin-top:1rem">
         <article class="card" aria-labelledby="content-health"><div class="card-head"><h3 id="content-health">Content Health Monitor</h3></div>
           <ul class="list">
             <li>


### PR DESCRIPTION
## Summary
- add `.grid.three` utility for three-column card layouts
- apply new class to content section to show four cards across three columns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a49bbb81f48333977d1ee11ea81869