### PR TITLE
Add SEO and Accessibility dashboard cards

### DIFF
--- a/dashboard-final.html
+++ b/dashboard-final.html
@@ -436,6 +436,64 @@
             </li>
           </ul>
         </article>
+
+        <article class="card" aria-labelledby="seo-overview"><div class="card-head"><h3 id="seo-overview">SEO Overview</h3><span class="pill ok">92 Score</span></div>
+          <ul class="list">
+            <li>
+              <div class="avatar" aria-hidden="true"><i class="fas fa-tags"></i></div>
+              <div>
+                <div>Meta descriptions</div>
+                <small style="color:var(--text-subtle)">95% complete</small>
+              </div>
+              <span class="pill ok">Good</span>
+            </li>
+            <li>
+              <div class="avatar" aria-hidden="true"><i class="fas fa-link"></i></div>
+              <div>
+                <div>Broken links</div>
+                <small style="color:var(--text-subtle)">4 detected</small>
+              </div>
+              <span class="pill warn">Fix</span>
+            </li>
+            <li>
+              <div class="avatar" aria-hidden="true"><i class="fas fa-sitemap"></i></div>
+              <div>
+                <div>Sitemap</div>
+                <small style="color:var(--text-subtle)">Up to date</small>
+              </div>
+              <span class="pill ok">Live</span>
+            </li>
+          </ul>
+        </article>
+
+        <article class="card" aria-labelledby="a11y-overview"><div class="card-head"><h3 id="a11y-overview">Accessibility</h3><span class="pill warn">AA</span></div>
+          <ul class="list">
+            <li>
+              <div class="avatar" aria-hidden="true"><i class="fas fa-adjust"></i></div>
+              <div>
+                <div>Contrast issues</div>
+                <small style="color:var(--text-subtle)">3 pages affected</small>
+              </div>
+              <span class="pill warn">Review</span>
+            </li>
+            <li>
+              <div class="avatar" aria-hidden="true"><i class="fas fa-image"></i></div>
+              <div>
+                <div>Missing alt text</div>
+                <small style="color:var(--text-subtle)">5 images</small>
+              </div>
+              <span class="pill bad">Fix</span>
+            </li>
+            <li>
+              <div class="avatar" aria-hidden="true"><i class="fas fa-universal-access"></i></div>
+              <div>
+                <div>ARIA landmarks</div>
+                <small style="color:var(--text-subtle)">Complete</small>
+              </div>
+              <span class="pill ok">Good</span>
+            </li>
+          </ul>
+        </article>
       </section>
 
       <section class="card" style="margin-top:1rem" aria-labelledby="quick-actions">


### PR DESCRIPTION
## Summary
- display key SEO metrics including meta descriptions, broken links and sitemap status
- highlight accessibility issues such as contrast, alt text, and ARIA landmarks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a49bfaee0c8333b86e90f78a10814c