### PR TITLE
Remove sidebar toggle from dashboards

### DIFF
--- a/dashboard-2.html
+++ b/dashboard-2.html
@@ -185,21 +185,6 @@
             display: none;
         }
 
-        .sidebar-toggle {
-            background: none;
-            border: none;
-            color: #666;
-            cursor: pointer;
-            font-size: 1rem;
-            padding: 0.25rem;
-            border-radius: 4px;
-            transition: all 0.2s ease;
-        }
-
-        .sidebar-toggle:hover {
-            background: #f0f0f0;
-            color: #1a1a1a;
-        }
 
         .nav-menu {
             padding: 1rem 0;

--- a/dashboard-5.html
+++ b/dashboard-5.html
@@ -77,9 +77,6 @@
     .layout { display: grid; grid-template-columns: 260px 1fr; min-height: calc(100vh - 64px); }
 
     nav[aria-label="Primary"] { border-right: 1px solid var(--border); background: var(--surface); }
-    .nav-header { display: flex; align-items: center; justify-content: space-between; padding: 1rem 1rem .5rem; }
-    .sidebar-toggle { background: none; border: 1px solid var(--border); border-radius: 8px; padding: .4rem .6rem; cursor: pointer; }
-
     .nav { display: grid; gap: .25rem; padding: .5rem; }
     .nav button { appearance: none; border: none; background: transparent; text-align: left; padding: .75rem .75rem; border-radius: 10px; display: flex; align-items: center; gap: .75rem; color: var(--text-subtle); font-weight: 600; cursor: pointer; }
     .nav button:hover { background: var(--surface-alt); color: var(--text); }
@@ -170,10 +167,6 @@
 
   <div class="layout">
     <nav aria-label="Primary">
-      <div class="nav-header">
-        <strong class="sr-only">Primary navigation</strong>
-        <button class="sidebar-toggle" id="toggleSidebar" aria-pressed="false" aria-label="Collapse sidebar"><i class="fas fa-bars"></i></button>
-      </div>
       <div class="nav" id="nav">
         <button aria-current="page"><i class="fas fa-tachometer-alt"></i> <span>Dashboard</span></button>
         <button><i class="fas fa-file-alt"></i> <span>Pages</span></button>
@@ -366,21 +359,6 @@
   <div class="toast" role="status" aria-live="polite" id="toast">Copied link to clipboard</div>
 
   <script>
-    // Sidebar collapse with persistence
-    (function(){
-      const btn = document.getElementById('toggleSidebar');
-      const root = document.querySelector('.layout');
-      const KEY = 'mw_sidebar_collapsed_v1';
-      const collapsed = localStorage.getItem(KEY) === '1';
-      if (collapsed) document.documentElement.style.setProperty('--sidebar-width','72px');
-      btn.addEventListener('click', () => {
-        const isCollapsed = localStorage.getItem(KEY) === '1';
-        localStorage.setItem(KEY, isCollapsed ? '0' : '1');
-        document.documentElement.style.setProperty('--sidebar-width', isCollapsed ? '260px' : '72px');
-        btn.setAttribute('aria-pressed', String(!isCollapsed));
-      });
-    })();
-
     // Search suggestions: basic a11y behavior
     (function(){
       const input = document.getElementById('q');

--- a/dashboard-final.html
+++ b/dashboard-final.html
@@ -77,9 +77,6 @@
     .layout { display: grid; grid-template-columns: 260px 1fr; min-height: calc(100vh - 64px); }
 
     nav[aria-label="Primary"] { border-right: 1px solid var(--border); background: var(--surface); }
-    .nav-header { display: flex; align-items: center; justify-content: space-between; padding: 1rem 1rem .5rem; }
-    .sidebar-toggle { background: none; border: 1px solid var(--border); border-radius: 8px; padding: .4rem .6rem; cursor: pointer; }
-
     .nav { display: grid; gap: .25rem; padding: .5rem; }
     .nav button { appearance: none; border: none; background: transparent; text-align: left; padding: .75rem .75rem; border-radius: 10px; display: flex; align-items: center; gap: .75rem; color: var(--text-subtle); font-weight: 600; cursor: pointer; }
     .nav button:hover { background: var(--surface-alt); color: var(--text); }
@@ -173,10 +170,6 @@
 
   <div class="layout">
     <nav aria-label="Primary">
-      <div class="nav-header">
-        <strong class="sr-only">Primary navigation</strong>
-        <button class="sidebar-toggle" id="toggleSidebar" aria-pressed="false" aria-label="Collapse sidebar"><i class="fas fa-bars"></i></button>
-      </div>
       <div class="nav" id="nav">
         <button aria-current="page"><i class="fas fa-tachometer-alt"></i> <span>Dashboard</span></button>
         <button><i class="fas fa-file-alt"></i> <span>Pages</span></button>
@@ -455,21 +448,6 @@
   <div class="toast" role="status" aria-live="polite" id="toast">Copied link to clipboard</div>
 
   <script>
-    // Sidebar collapse with persistence
-    (function(){
-      const btn = document.getElementById('toggleSidebar');
-      const root = document.querySelector('.layout');
-      const KEY = 'mw_sidebar_collapsed_v1';
-      const collapsed = localStorage.getItem(KEY) === '1';
-      if (collapsed) document.documentElement.style.setProperty('--sidebar-width','72px');
-      btn.addEventListener('click', () => {
-        const isCollapsed = localStorage.getItem(KEY) === '1';
-        localStorage.setItem(KEY, isCollapsed ? '0' : '1');
-        document.documentElement.style.setProperty('--sidebar-width', isCollapsed ? '260px' : '72px');
-        btn.setAttribute('aria-pressed', String(!isCollapsed));
-      });
-    })();
-
     // Search suggestions: basic a11y behavior
     (function(){
       const input = document.getElementById('q');


### PR DESCRIPTION
## Summary
- remove unused sidebar toggle button, CSS, and JS from dashboard-5 and dashboard-final templates
- clean up leftover sidebar-toggle styles in dashboard-2

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_68a49b90ea7883338e14d6e66d594987